### PR TITLE
Fix build dependency error with ed25519

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.7.1"
 version = "^0.5.5"
 
 [dependencies.ed25519-dalek]
-version = "=0.8.0"
+version = "^0.8.0"
 
 [dependencies.clear_on_drop]
 features = ["no_cc"]


### PR DESCRIPTION
Fix the following build issue:

```
    Updating crates.io index
error: failed to select a version for the requirement `subtle = "^0.7"`
  candidate versions found which didn't match: 2.0.0, 1.0.0
  location searched: crates.io index
required by package `curve25519-dalek v0.19.1`
    ... which is depended on by `ed25519-dalek v0.8.0`
    ... which is depended on by `ewasm-precompile-ed25519 v0.0.1 (/home/gballet/src/ewasm-precompiles/ed25519)`
Makefile:4: recipe for target 'all' failed
make: *** [all] Error 101
```