### PR TITLE
Pad ripemd160 hash to 32 bytes

### DIFF
--- a/ripemd160/src/lib.rs
+++ b/ripemd160/src/lib.rs
@@ -20,5 +20,9 @@ pub extern "C" fn main() {
     hasher.input(&data);
     let hash = hasher.result();
 
-    ewasm_api::finish_data(&hash)
+    // As per YP the 20 byte hash should be left-padded to 32 bytes
+    let mut padded_hash = vec![0; 12];
+    padded_hash.extend_from_slice(&hash);
+
+    ewasm_api::finish_data(&padded_hash)
 }


### PR DESCRIPTION
Type of the `hash` variable is `generic_array::GenericArray<u8, typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UInt<typenum::uint::UTerm, typenum::bit::B1>, typenum::bit::B0>, typenum::bit::B1>, typenum::bit::B0>, typenum::bit::B0>>`! Rust is amazing :smile: 