### PR TITLE
Use panic and not revert in Byzantium precompiles

### DIFF
--- a/ecadd/src/lib.rs
+++ b/ecadd/src/lib.rs
@@ -16,11 +16,7 @@ pub extern "C" fn main() {
 
     let mut output = [0u8; 64];
     match ethereum_bn128::bn128_add(&input[..], &mut BytesRef::Fixed(&mut output[..])) {
-        Ok(_) => {
-            ewasm_api::finish_data(&output);
-        }
-        Err(_) => {
-            ewasm_api::revert();
-        }
+        Ok(_) => ewasm_api::finish_data(&output),
+        Err(_) => panic!(),
     }
 }

--- a/ecmul/src/lib.rs
+++ b/ecmul/src/lib.rs
@@ -16,11 +16,7 @@ pub extern "C" fn main() {
 
     let mut output = [0u8; 64];
     match ethereum_bn128::bn128_mul(&input[..], &mut BytesRef::Fixed(&mut output[..])) {
-        Ok(_) => {
-            ewasm_api::finish_data(&output);
-        }
-        Err(_) => {
-            ewasm_api::revert();
-        }
+        Ok(_) => ewasm_api::finish_data(&output),
+        Err(_) => panic!(),
     }
 }

--- a/ecpairing/src/lib.rs
+++ b/ecpairing/src/lib.rs
@@ -12,7 +12,7 @@ pub extern "C" fn main() {
     // NOTE: this validation will also be done by bn128_pairing
 
     if length % 192 != 0 {
-        ewasm_api::revert();
+        panic!();
     }
 
     // charge a base fee plus a word fee for every element
@@ -26,11 +26,7 @@ pub extern "C" fn main() {
 
     let mut output = [0u8; 32];
     match ethereum_bn128::bn128_pairing(&input[..], &mut BytesRef::Fixed(&mut output[..])) {
-        Ok(_) => {
-            ewasm_api::finish_data(&output);
-        }
-        Err(_) => {
-            ewasm_api::revert();
-        }
+        Ok(_) => ewasm_api::finish_data(&output),
+        Err(_) => panic!(),
     }
 }

--- a/ecrecover/src/lib.rs
+++ b/ecrecover/src/lib.rs
@@ -72,7 +72,7 @@ pub extern "C" fn main() {
 
     match ecrecover(&input) {
         Ok(ret) => ewasm_api::finish_data(&ret[..]),
-        Err(e) => panic!("Error recovering public key: {:?}", e),
+        Err(_) => panic!(),
     }
 }
 


### PR DESCRIPTION
Upon encountering an error in a precompile, `geth` will OOG and this PR aims at reproducing this behavior.