### PR TITLE
Size optimisations (turn on -Os)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ members = [
 
 [profile.release]
 lto = true
+opt-level = 'z'
+debug = false


### PR DESCRIPTION
Also request debug=false to avoid debug sections, but it doesn't seem to take effect.

However it does gives some returns:
```
-rwxr-xr-x  2 alex  staff  120283  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_blake2.wasm
-rwxr-xr-x  2 alex  staff  361623  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_bls12pairing.wasm
-rwxr-xr-x  2 alex  staff  185502  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_ecadd.wasm
-rwxr-xr-x  2 alex  staff  189049  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_ecmul.wasm
-rwxr-xr-x  2 alex  staff  543614  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_ecpairing.wasm
-rwxr-xr-x  2 alex  staff  348050  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_ed25519.wasm
-rwxr-xr-x  2 alex  staff   93802  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_identity.wasm
-rwxr-xr-x  2 alex  staff  110377  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_keccak256.wasm
-rwxr-xr-x  2 alex  staff  125299  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_ripemd160.wasm
-rwxr-xr-x  2 alex  staff  111974  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_sha1.wasm
-rwxr-xr-x  2 alex  staff  113718  7 Feb 23:28 target/wasm32-unknown-unknown/release/ewasm_precompile_sha256.wasm
```
vs
```
-rwxr-xr-x  2 alex  staff  114037  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_blake2.wasm
-rwxr-xr-x  2 alex  staff  443517  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_bls12pairing.wasm
-rwxr-xr-x  2 alex  staff  270367  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_ecadd.wasm
-rwxr-xr-x  2 alex  staff  272555  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_ecmul.wasm
-rwxr-xr-x  2 alex  staff  208402  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_ecpairing.wasm
-rwxr-xr-x  2 alex  staff  236134  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_ed25519.wasm
-rwxr-xr-x  2 alex  staff   87991  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_identity.wasm
-rwxr-xr-x  2 alex  staff  106253  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_keccak256.wasm
-rwxr-xr-x  2 alex  staff  124329  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_ripemd160.wasm
-rwxr-xr-x  2 alex  staff  104034  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_sha1.wasm
-rwxr-xr-x  2 alex  staff  117858  7 Feb 23:33 target/wasm32-unknown-unknown/release/ewasm_precompile_sha256.wasm
```

Split off #32.

