### PR TITLE
Revert "Use keccak-hash from Parity for size/speed optimisations in ecrecover

### DIFF
--- a/ecrecover/Cargo.toml
+++ b/ecrecover/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 ewasm_api = "0.5"
 libsecp256k1 = "^0.2.1"
-keccak-hash = { git = "https://github.com/paritytech/parity-common", version = "0.1.2" }
+sha3 = "^0.6"
 
 [dev-dependencies]
 rustc-hex = "1.0"

--- a/ecrecover/src/lib.rs
+++ b/ecrecover/src/lib.rs
@@ -1,10 +1,11 @@
 extern crate ewasm_api;
-extern crate keccak_hash;
 extern crate secp256k1;
+extern crate sha3;
 
 #[cfg(test)]
 use secp256k1::Error::InvalidSignature;
 use secp256k1::{recover, Message, RecoveryId, Signature};
+use sha3::{Digest, Keccak256};
 use std::cmp::min;
 
 const HASH_OFFSET: usize = 0;
@@ -47,7 +48,7 @@ fn ecrecover(input: &[u8]) -> Result<Vec<u8>, secp256k1::Error> {
 
     let key = recover(&message, &sig, &rec_id)?;
     let ret = key.serialize();
-    let ret = keccak_hash::keccak(&ret[1..65]);
+    let ret = Keccak256::digest(&ret[1..65]);
     let mut output = vec![0u8; 12];
     output.extend_from_slice(&ret[12..32]);
     Ok(output)

--- a/keccak256/Cargo.toml
+++ b/keccak256/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 ewasm_api = "0.5"
-keccak-hash = { git = "https://github.com/paritytech/parity-common", version = "0.1.2" }
+sha3 = "^0.6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/keccak256/src/lib.rs
+++ b/keccak256/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate ewasm_api;
-extern crate keccak_hash;
+extern crate sha3;
+
+use sha3::{Digest, Keccak256};
 
 #[cfg(not(test))]
 #[no_mangle]
@@ -15,7 +17,7 @@ pub extern "C" fn main() {
 
     let data = ewasm_api::unsafe_calldata_copy(0, length);
 
-    let hash = keccak_hash::keccak(data);
+    let hash = Keccak256::digest(&data[..]);
 
     ewasm_api::finish_data(&hash[..])
 }


### PR DESCRIPTION
Revert #54. Seems like in the meanwhile this got broken.