### PR TITLE
Fix ed25519 compilation

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -11,13 +11,13 @@ edition = "2018"
 [dependencies]
 ewasm_api = "0.9"
 hex = "0.3.1"
-sha2 = "0.7.1"
+sha2 = "^0.8"
 
 [dependencies.rand]
-version = "^0.5.5"
+version = "0.6.0"
 
 [dependencies.ed25519-dalek]
-version = "^0.8.0"
+version = "0.9.1"
 
 [dependencies.clear_on_drop]
 features = ["no_cc"]


### PR DESCRIPTION
Set fixed dependency for ed25519-dalek (and its dependencies). The old version is not available anymore.