### PR TITLE
Bump ethereum-bn128 dependency to 0.1.1 (for ecadd/ecmul/ecpairing)

### DIFF
--- a/ecadd/Cargo.toml
+++ b/ecadd/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 ewasm_api = "0.9"
-ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.0" }
+ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.1" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/ecmul/Cargo.toml
+++ b/ecmul/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 ewasm_api = "0.9"
-ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.0" }
+ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.1" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/ecpairing/Cargo.toml
+++ b/ecpairing/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 ewasm_api = "0.9"
-ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.0" }
+ethereum-bn128 = { git = "https://github.com/ewasm/ethereum-bn128.rs", tag = "0.1.1" }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Fixes #77.